### PR TITLE
Enable TravisCI

### DIFF
--- a/.smalltalk.ston
+++ b/.smalltalk.ston
@@ -1,0 +1,8 @@
+SmalltalkCISpec {
+  #loading : [
+    SCIMetacelloLoadSpec {
+      #baseline : 'Units',
+      #directory : 'src'
+    }
+  ]
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: smalltalk
+sudo: false
+
+os:
+- linux
+- osx
+
+smalltalk:
+  - Pharo-7.0
+  - Pharo-6.1
+
+matrix:
+  fast_finish: true


### PR DESCRIPTION
Fixes #5

An admin will need to enable the hook for travis CI and to enable the build.